### PR TITLE
Prepare release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.4.1 - 2025-08-29
+
+### Changed
+- npm packages updated 
+- max NC version bumped to 32
+- icons changed to outlined versions
+
 ## 2.4.0 - 2025-01-09
 
 Maintenance update.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<summary>Collaborative whiteboard integration</summary>
 	<description><![CDATA[Modern collaborative whiteboard in Nextcloud.
 This integration app lets users create Excalidraw boards, share board links and open boards directly in Nextcloud.]]></description>
-	<version>2.4.0</version>
+	<version>2.4.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Excalidraw</namespace>


### PR DESCRIPTION
### Changed
- npm packages updated 
- max NC version bumped to 32
- icons changed to outlined versions